### PR TITLE
Pullreq nml

### DIFF
--- a/config/support-boost.m4
+++ b/config/support-boost.m4
@@ -122,12 +122,13 @@ if test \
    -o "x$rose_boost_version" = "x105000" -o "x$_version" = "x1.50" \
    -o "x$rose_boost_version" = "x105100" -o "x$_version" = "x1.51" \
    -o "x$rose_boost_version" = "x105200" -o "x$_version" = "x1.52" \
-   -o "x$rose_boost_version" = "x105300" -o "x$_version" = "x1.53"
+   -o "x$rose_boost_version" = "x105300" -o "x$_version" = "x1.53" \
+   -o "x$rose_boost_version" = "x105400" -o "x$_version" = "x1.54"
 then
     echo "Reasonable version of Boost found!"
 else
   if test "x$ROSE_ENABLE_BOOST_VERSION_CHECK" = "xyes"; then
-    ROSE_MSG_ERROR([Unsupported version of Boost: '$rose_boost_version'. Only 1.45 to 1.53 is currently supported.])
+    ROSE_MSG_ERROR([Unsupported version of Boost: '$rose_boost_version'. Only 1.45 to 1.54 is currently supported.])
   else
     AC_MSG_WARN([Unsupported version of Boost is being used])
   fi

--- a/src/backend/unparser/FortranCodeGeneration/unparseFortran_statements.C
+++ b/src/backend/unparser/FortranCodeGeneration/unparseFortran_statements.C
@@ -3287,7 +3287,8 @@ FortranCodeGeneration_locatedNode::unparseWriteStatement(SgStatement* stmt, SgUn
 
      unparse_IO_Control_Support("FMT",writeStatement->get_format(),false,info);
      unparse_IO_Control_Support("REC",writeStatement->get_rec(),false,info);
-     unparse_IO_Control_Support("NLT",writeStatement->get_namelist(),false,info);
+     // Hiro (2014.11.6): NML should be used instead of NLT
+     unparse_IO_Control_Support("NML",writeStatement->get_namelist(),false,info);
      unparse_IO_Control_Support("ADVANCE",writeStatement->get_advance(),false,info);
 
   // F2003 specific

--- a/src/midend/programAnalysis/systemDependenceGraph/newCDG.C
+++ b/src/midend/programAnalysis/systemDependenceGraph/newCDG.C
@@ -178,7 +178,11 @@ bool ControlDependenceGraph::checkCycle(const ControlFlowGraph& cfg)
         boost::add_edge(cfgCopy.getExit(), cfgCopy.getEntry(), cfgCopy);
 
         std::vector<int> component(num_vertices(cfgCopy));
-        int num = boost::strong_components(cfgCopy, &component[0]);
+        int num = boost::strong_components(cfgCopy,
+            make_iterator_property_map(component.begin(),
+                                       get(boost::vertex_index,cfgCopy),
+                                       component[0]));
+        //int num = boost::strong_components(cfgCopy, &component[0]);
 
         return num == 1;
 }


### PR DESCRIPTION
I fixed a bug that was previously reported by Naoya Maruyama (see his post to Rose-public mailing list on Aug 24, 2013). The Fortran unparser uses "NLT" (instead of NML) for the name list in the WRITE statement. This seems to cause compilation errors as follows.

tacky@icecream% gfortran name+.f90
name+.f90:6.13:

  write(*,nlt=name1)
             1
Error: Syntax error in WRITE statement at (1)
