### PR TITLE
Set the source position of CONTAINS statement in Fortran

### DIFF
--- a/config/support-boost.m4
+++ b/config/support-boost.m4
@@ -122,12 +122,13 @@ if test \
    -o "x$rose_boost_version" = "x105000" -o "x$_version" = "x1.50" \
    -o "x$rose_boost_version" = "x105100" -o "x$_version" = "x1.51" \
    -o "x$rose_boost_version" = "x105200" -o "x$_version" = "x1.52" \
-   -o "x$rose_boost_version" = "x105300" -o "x$_version" = "x1.53"
+   -o "x$rose_boost_version" = "x105300" -o "x$_version" = "x1.53" \
+   -o "x$rose_boost_version" = "x105400" -o "x$_version" = "x1.54"
 then
     echo "Reasonable version of Boost found!"
 else
   if test "x$ROSE_ENABLE_BOOST_VERSION_CHECK" = "xyes"; then
-    ROSE_MSG_ERROR([Unsupported version of Boost: '$rose_boost_version'. Only 1.45 to 1.53 is currently supported.])
+    ROSE_MSG_ERROR([Unsupported version of Boost: '$rose_boost_version'. Only 1.45 to 1.54 is currently supported.])
   else
     AC_MSG_WARN([Unsupported version of Boost is being used])
   fi

--- a/src/frontend/OpenFortranParser_SAGE_Connection/FortranParserActionROSE.C
+++ b/src/frontend/OpenFortranParser_SAGE_Connection/FortranParserActionROSE.C
@@ -19246,7 +19246,8 @@ void c_action_label(Token_t * lbl)
                 keyword != NULL ? keyword->text : "NULL");
 
         SgContainsStatement* containsStatement = new SgContainsStatement();
-        SageInterface::setSourcePosition(containsStatement);
+        //SageInterface::setSourcePosition(containsStatement);
+        setSourcePosition(containsStatement,keyword);
         containsStatement->set_definingDeclaration(containsStatement);
 
         astScopeStack.front()->append_statement(containsStatement);

--- a/src/midend/programAnalysis/systemDependenceGraph/newCDG.C
+++ b/src/midend/programAnalysis/systemDependenceGraph/newCDG.C
@@ -178,7 +178,11 @@ bool ControlDependenceGraph::checkCycle(const ControlFlowGraph& cfg)
         boost::add_edge(cfgCopy.getExit(), cfgCopy.getEntry(), cfgCopy);
 
         std::vector<int> component(num_vertices(cfgCopy));
-        int num = boost::strong_components(cfgCopy, &component[0]);
+        int num = boost::strong_components(cfgCopy,
+            make_iterator_property_map(component.begin(),
+                                       get(boost::vertex_index,cfgCopy),
+                                       component[0]));
+        //int num = boost::strong_components(cfgCopy, &component[0]);
 
         return num == 1;
 }


### PR DESCRIPTION
Fix a bug that the source position of a CONTAINS statement is not set correctly. This bug moves the comments and directives written around the statement. So it should be fixed.
