### PR TITLE
Add missing dependency on the ROSE public config header file

### DIFF
--- a/src/util/commandlineProcessing/CMakeLists.txt
+++ b/src/util/commandlineProcessing/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(util_commandlineProcessing OBJECT
   commandline_processing.C
   sla++.C
 )
+add_dependencies(util_commandlineProcessing generate_rosePublicConfig)
 
 ########### install files ###############
 install(FILES


### PR DESCRIPTION
Without this patch, building with ninja -j 1 fails because commandline_processing.C includes rosePublicConfig.h which is not build yet since there is no dependency.