### PR TITLE
Replaced 3 functions deprecated in cpp11

### DIFF
--- a/src/frontend/SageIII/virtualCFG/filteredCFGImpl.h
+++ b/src/frontend/SageIII/virtualCFG/filteredCFGImpl.h
@@ -111,8 +111,8 @@ namespace VirtualCFG
     {
         std::vector < CFGPath > paths(orig.begin(), orig.end()); // convert each raw edges into a path: 1-to-1 conversion for now
         return makeClosure < FilteredEdge > (paths, 
-                                             std::mem_fun_ref(closure),
-                                             std::mem_fun_ref(otherSide), 
+                                             std::mem_fn(closure),
+                                             std::mem_fn(otherSide),
                                              filter,
                                              merge);
     }

--- a/src/midend/astQuery/astQuery.h
+++ b/src/midend/astQuery/astQuery.h
@@ -338,7 +338,7 @@ template<typename NodeFunctional>
      _Result querySubTree ( SgNode * subTree,
         _Result (*__x)(SgNode*,_Arg), _Arg x_arg,
         AstQueryNamespace::QueryDepth defineQueryType = AstQueryNamespace::AllNodes ){
-      return querySubTree(subTree,std::bind2nd(std::ptr_fun(__x),x_arg),defineQueryType);
+      return querySubTree(subTree,std::bind(std::ptr_fun(__x),std::placeholders::_1,x_arg),defineQueryType);
     }
 
   /********************************************************************************
@@ -389,7 +389,7 @@ template<typename NodeFunctional>
   template <class _Arg, class _Result> 
     _Result queryRange ( typename _Result::iterator begin, const typename _Result::iterator end,
         _Result (*__x)(SgNode*,_Arg), _Arg x_arg){
-      return queryRange(begin,end,std::bind2nd(std::ptr_fun(__x),x_arg));
+      return queryRange(begin,end,std::bind(std::ptr_fun(__x), std::placeholders::_1,x_arg));
     }
 
   /********************************************************************************
@@ -453,7 +453,7 @@ template <class _Arg, class _Result>
 _Result queryMemoryPool ( 
     _Result (*__x)(SgNode*,_Arg), _Arg x_arg,
     VariantVector* targetVariantVector = NULL){
-  return queryMemoryPool(std::bind2nd(std::ptr_fun(__x),x_arg),targetVariantVector);
+  return queryMemoryPool(std::bind(std::ptr_fun(__x),std::placeholders::_1,x_arg),targetVariantVector);
 }
 
 /********************************************************************************

--- a/src/midend/astQuery/nameQuery.C
+++ b/src/midend/astQuery/nameQuery.C
@@ -1042,7 +1042,7 @@ NameQuery::queryNameTypeName (SgNode * astNode)
 
 
 
-std::pointer_to_unary_function<SgNode*, Rose_STL_Container<std::string> > NameQuery::getFunction(NameQuery::TypeOfQueryTypeOneParameter oneParam){
+std::function<Rose_STL_Container<std::string>(SgNode*) > NameQuery::getFunction(NameQuery::TypeOfQueryTypeOneParameter oneParam){
            NameQuery::roseFunctionPointerOneParameter __x; 
      switch (oneParam)
         {
@@ -1137,7 +1137,7 @@ std::pointer_to_unary_function<SgNode*, Rose_STL_Container<std::string> > NameQu
 
   }
 
-std::pointer_to_binary_function<SgNode*, std::string, Rose_STL_Container<std::string> > NameQuery::getFunction(NameQuery::TypeOfQueryTypeTwoParameters twoParam){
+std::function< Rose_STL_Container<std::string>(SgNode*, std::string) > NameQuery::getFunction(NameQuery::TypeOfQueryTypeTwoParameters twoParam){
      NameQuery::roseFunctionPointerTwoParameters __x;
      switch (twoParam)
         {
@@ -1177,9 +1177,7 @@ std::pointer_to_binary_function<SgNode*, std::string, Rose_STL_Container<std::st
                     NameQuery::roseFunctionPointerTwoParameters querySolverFunction,
                     AstQueryNamespace::QueryDepth defineQueryType){
                      return AstQueryNamespace::querySubTree(subTree, 
-                                  std::bind2nd(std::ptr_fun(querySolverFunction),traversal), defineQueryType);
-        
-
+                                  std::bind(std::ptr_fun(querySolverFunction), std::placeholders::_1, traversal), defineQueryType);
           };
           NameQuerySynthesizedAttributeType NameQuery::querySubTree
                   ( SgNode * subTree,
@@ -1187,7 +1185,7 @@ std::pointer_to_binary_function<SgNode*, std::string, Rose_STL_Container<std::st
                     NameQuery::TypeOfQueryTypeTwoParameters elementReturnType,
                     AstQueryNamespace::QueryDepth defineQueryType ){
                     return AstQueryNamespace::querySubTree(subTree, 
-                                  std::bind2nd(getFunction(elementReturnType),traversal), defineQueryType);
+                                  std::bind(getFunction(elementReturnType), std::placeholders::_1 , traversal), defineQueryType);
           };
 
 
@@ -1225,7 +1223,7 @@ std::pointer_to_binary_function<SgNode*, std::string, Rose_STL_Container<std::st
                    std::string targetNode,
                    NameQuery::roseFunctionPointerTwoParameters querySolverFunction ){
                 return AstQueryNamespace::queryRange(nodeList.begin(), nodeList.end(),
-                             std::bind2nd(std::ptr_fun(querySolverFunction), targetNode));
+                             std::bind(std::ptr_fun(querySolverFunction), std::placeholders::_1, targetNode));
 //                                  std::bind2nd(getFunction(elementReturnType),traversal), defineQueryType);
 
           };
@@ -1234,7 +1232,7 @@ std::pointer_to_binary_function<SgNode*, std::string, Rose_STL_Container<std::st
                    std::string targetNode,
                    NameQuery::TypeOfQueryTypeTwoParameters elementReturnType ){
                 return AstQueryNamespace::queryRange(nodeList.begin(), nodeList.end(),
-                             std::bind2nd(getFunction(elementReturnType), targetNode));
+                             std::bind(getFunction(elementReturnType), std::placeholders::_1, targetNode));
 
           };
 
@@ -1257,7 +1255,7 @@ NameQuerySynthesizedAttributeType
      NameQuery::roseFunctionPointerTwoParameters querySolverFunction, VariantVector* targetVariantVector)
    {
          return AstQueryNamespace::queryMemoryPool(
-                                  std::bind2nd(std::ptr_fun(querySolverFunction),traversal), targetVariantVector);
+                                  std::bind(std::ptr_fun(querySolverFunction), std::placeholders::_1, traversal), targetVariantVector);
 
    };
 
@@ -1300,7 +1298,7 @@ NameQuerySynthesizedAttributeType
      VariantVector* targetVariantVector)
    {
  return AstQueryNamespace::queryMemoryPool( 
-                                  std::bind2nd(getFunction(elementReturnType),traversal), targetVariantVector);
+                                  std::bind(getFunction(elementReturnType), std::placeholders::_1, traversal), targetVariantVector);
 
 
    };

--- a/src/midend/astQuery/nameQuery.h
+++ b/src/midend/astQuery/nameQuery.h
@@ -101,20 +101,21 @@ namespace NameQuery{
 
   /**************************************************************************************************************
    * The function
-   *    std::pointer_to_unary_function<SgNode*, std::list<SgNode*> > getFunction(TypeOfQueryTypeOneParameter oneParam);
+   *    std::function<Rose_STL_Container<std::string>(SgNode *)> getFunction(TypeOfQueryTypeOneParameter oneParam);
    * will return a functor wrapping the pre-implemented function for TypeOfQueryTypeOneParameter.
    **************************************************************************************************************/
 
-  std::pointer_to_unary_function < SgNode *,
-    Rose_STL_Container<std::string> >getFunction (TypeOfQueryTypeOneParameter oneParam);
+  std::function<Rose_STL_Container<std::string>(SgNode *)> getFunction(TypeOfQueryTypeOneParameter oneParam);
 
   /**************************************************************************************************************
    * The function
-   * std::pointer_to_binary_function<SgNode*, SgNode*, std::list<SgNode*> > getFunction(TypeOfQueryTypeTwoParameters twoParam);
+   *    std::function<Rose_STL_Container<std::string>(SgNode *, std::string)>
+   *       getFunction(TypeOfQueryTypeTwoParameters twoParam);
    * will return a functor wrapping the pre-implemented function for TypeOfQueryTypeTwoParameters.
    **************************************************************************************************************/
-  std::pointer_to_binary_function < SgNode *, std::string,
-    Rose_STL_Container<std::string> > getFunction (TypeOfQueryTypeTwoParameters twoParam);
+
+  std::function<Rose_STL_Container<std::string>(SgNode *, std::string)>
+     getFunction(TypeOfQueryTypeTwoParameters twoParam);
 
   // get the SgNode's conforming to the test in querySolverFunction or
   // get the SgNode's conforming to the test in the TypeOfQueryTypeOneParamter the user specify.

--- a/src/midend/astQuery/nodeQuery.C
+++ b/src/midend/astQuery/nodeQuery.C
@@ -23,7 +23,7 @@ using namespace AstQueryNamespace;
 
 #include "queryVariant.C"
 
-  std::pointer_to_unary_function<SgNode*, Rose_STL_Container<SgNode*> > 
+std::function<Rose_STL_Container<SgNode*>(SgNode*) >
 NodeQuery::getFunction(TypeOfQueryTypeOneParameter oneParam)
 {
   Rose_STL_Container<SgNode*> (*__x)(SgNode*); 
@@ -120,7 +120,7 @@ NodeQuery::getFunction(TypeOfQueryTypeOneParameter oneParam)
 
 }
 
-  std::pointer_to_binary_function<SgNode*, SgNode*, Rose_STL_Container<SgNode*> > 
+std::function< Rose_STL_Container<SgNode*>(SgNode*, SgNode*) >
 NodeQuery::getFunction(TypeOfQueryTypeTwoParameters twoParam)
 {
   Rose_STL_Container<SgNode*> (*__x)(SgNode*,SgNode*); 
@@ -947,7 +947,7 @@ NodeQuerySynthesizedAttributeType NodeQuery::querySubTree ( SgNode * subTree, Sg
 #if 0
      printf ("Inside of NodeQuery::querySubTree #2 \n");
 #endif
-     return AstQueryNamespace::querySubTree(subTree, std::bind2nd(std::ptr_fun(querySolverFunction),traversal), defineQueryType);
+     return AstQueryNamespace::querySubTree(subTree, std::bind(std::ptr_fun(querySolverFunction),std::placeholders::_1,traversal), defineQueryType);
    }
 
 NodeQuerySynthesizedAttributeType NodeQuery::querySubTree ( SgNode * subTree, SgNode * traversal, TypeOfQueryTypeTwoParameters elementReturnType, AstQueryNamespace::QueryDepth defineQueryType )
@@ -955,7 +955,7 @@ NodeQuerySynthesizedAttributeType NodeQuery::querySubTree ( SgNode * subTree, Sg
 #if 0
      printf ("Inside of NodeQuery::querySubTree #3 \n");
 #endif
-     return AstQueryNamespace::querySubTree(subTree, std::bind2nd(getFunction(elementReturnType),traversal), defineQueryType);
+     return AstQueryNamespace::querySubTree(subTree, std::bind(getFunction(elementReturnType),std::placeholders::_1,traversal), defineQueryType);
    }
 
 
@@ -989,7 +989,7 @@ Rose_STL_Container<SgNode*> NodeQuery::queryNodeList ( Rose_STL_Container<SgNode
 
 Rose_STL_Container<SgNode*> NodeQuery::queryNodeList ( Rose_STL_Container<SgNode*> nodeList, SgNode * targetNode, TypeOfQueryTypeTwoParameters elementReturnType )
    {
-     return AstQueryNamespace::queryRange(nodeList.begin(), nodeList.end(), std::bind2nd(getFunction(elementReturnType), targetNode));
+     return AstQueryNamespace::queryRange(nodeList.begin(), nodeList.end(), std::bind(getFunction(elementReturnType), std::placeholders::_1, targetNode));
    }
 
 // DQ (4/8/2004): Added query based on vector of variants
@@ -1137,7 +1137,7 @@ Rose_STL_Container<SgNode*> NodeQuery::generateListOfTypes ( SgNode* astNode )
 
     // DQ (2/16/2007): This is Andreas's fix for the performance problem represented by the previous 
     // implementat which built and returns STL lists by value with only a single IR node in the list.
-    AstQueryNamespace::queryMemoryPool(std::bind2nd(funcTest,&nodeList),&ir_nodes); 
+    AstQueryNamespace::queryMemoryPool(std::bind(funcTest,std::placeholders::_1,&nodeList),&ir_nodes);
   }
   else
   {
@@ -1193,7 +1193,7 @@ Rose_STL_Container<SgNode*> NodeQuery::generateListOfTypes ( SgNode* astNode )
   NodeQuerySynthesizedAttributeType
 NodeQuery::queryMemoryPool ( SgNode * traversal, NodeQuery::roseFunctionPointerTwoParameters querySolverFunction, VariantVector* targetVariantVector)
 {
-  return AstQueryNamespace::queryMemoryPool(std::bind2nd(std::ptr_fun(querySolverFunction),traversal), targetVariantVector);
+  return AstQueryNamespace::queryMemoryPool(std::bind(std::ptr_fun(querySolverFunction),std::placeholders::_1,traversal), targetVariantVector);
 }
 
 
@@ -1224,7 +1224,7 @@ NodeQuery::queryMemoryPool ( SgNode * traversal, NodeQuery::roseFunctionPointerO
   NodeQuerySynthesizedAttributeType
 NodeQuery::queryMemoryPool (SgNode * traversal, NodeQuery::TypeOfQueryTypeTwoParameters elementReturnType, VariantVector* targetVariantVector)
 {
-  return AstQueryNamespace::queryMemoryPool(std::bind2nd(getFunction(elementReturnType),traversal), targetVariantVector);
+  return AstQueryNamespace::queryMemoryPool(std::bind(getFunction(elementReturnType),std::placeholders::_1,traversal), targetVariantVector);
 }
 
 /********************************************************************************

--- a/src/midend/astQuery/nodeQuery.h
+++ b/src/midend/astQuery/nodeQuery.h
@@ -167,20 +167,20 @@ namespace NodeQuery
 
        /**************************************************************************************************************
         * The function
-        *    std::pointer_to_unary_function<SgNode*, std::list<SgNode*> > getFunction(TypeOfQueryTypeOneParameter oneParam);
+        *    std::function<Rose_STL_Container<SgNode*>(SgNode *)> getFunction(TypeOfQueryTypeOneParameter oneParam);
         * will return a functor wrapping the pre-implemented function for TypeOfQueryTypeOneParameter.
         **************************************************************************************************************/
-  std::pointer_to_unary_function < SgNode *,
-  Rose_STL_Container<SgNode*> >getFunction (TypeOfQueryTypeOneParameter oneParam);
+
+  std::function<Rose_STL_Container<SgNode*>(SgNode *)> getFunction(TypeOfQueryTypeOneParameter oneParam);
 
        /**************************************************************************************************************
         * The function
-        * std::pointer_to_binary_function<SgNode*, SgNode*, std::list<SgNode*> > getFunction(TypeOfQueryTypeTwoParameters twoParam);
+        *    std::function<Rose_STL_Container<SgNode*>(SgNode *, SgNode *)>
+        *       getFunction(TypeOfQueryTypeTwoParameters twoParam);
         * will return a functor wrapping the pre-implemented function for TypeOfQueryTypeTwoParameters.
         **************************************************************************************************************/
-  std::pointer_to_binary_function < SgNode *, SgNode *,
-    Rose_STL_Container<SgNode*> > getFunction (TypeOfQueryTypeTwoParameters twoParam);
 
+  std::function<Rose_STL_Container<SgNode*>(SgNode *, SgNode *)> getFunction(TypeOfQueryTypeTwoParameters twoParam);
 
 
   // Functions supporting the query of variants

--- a/src/midend/astQuery/numberQuery.C
+++ b/src/midend/astQuery/numberQuery.C
@@ -268,7 +268,7 @@ NumberQuery::queryNumberOfArgsInScalarIndexingOperator (SgNode * astNode)
 } // End function queryNumberOfArgsInScalarIndexingOperator() 
 
 
-std::pointer_to_unary_function<SgNode*, NumberQuerySynthesizedAttributeType> NumberQuery::getFunction(NumberQuery::TypeOfQueryTypeOneParameter oneParam){
+std::function<NumberQuerySynthesizedAttributeType(SgNode*)> NumberQuery::getFunction(NumberQuery::TypeOfQueryTypeOneParameter oneParam){
   NumberQuery::roseFunctionPointerOneParameter __x; 
   switch (oneParam)
   {
@@ -298,7 +298,7 @@ std::pointer_to_unary_function<SgNode*, NumberQuerySynthesizedAttributeType> Num
 
 }
 
-std::pointer_to_binary_function<SgNode*, std::string, NumberQuerySynthesizedAttributeType > NumberQuery::getFunction(NumberQuery::TypeOfQueryTypeTwoParameters twoParam){
+std::function<NumberQuerySynthesizedAttributeType(SgNode*, std::string) > NumberQuery::getFunction(NumberQuery::TypeOfQueryTypeTwoParameters twoParam){
   NumberQuery::roseFunctionPointerTwoParameters __x;
   switch (twoParam)
   {
@@ -339,7 +339,7 @@ NumberQuerySynthesizedAttributeType NumberQuery::querySubTree
   NumberQuery::roseFunctionPointerTwoParameters querySolverFunction,
   AstQueryNamespace::QueryDepth defineQueryType){
   return AstQueryNamespace::querySubTree(subTree, 
-      std::bind2nd(std::ptr_fun(querySolverFunction),traversal), defineQueryType);
+      std::bind(std::ptr_fun(querySolverFunction),std::placeholders::_1,traversal), defineQueryType);
 
 
 };
@@ -349,7 +349,7 @@ NumberQuerySynthesizedAttributeType NumberQuery::querySubTree
   NumberQuery::TypeOfQueryTypeTwoParameters elementReturnType,
   AstQueryNamespace::QueryDepth defineQueryType ){
   return AstQueryNamespace::querySubTree(subTree, 
-      std::bind2nd(getFunction(elementReturnType),traversal), defineQueryType);
+      std::bind(getFunction(elementReturnType),std::placeholders::_1,traversal), defineQueryType);
 };
 
 
@@ -360,6 +360,7 @@ NumberQuerySynthesizedAttributeType NumberQuery::queryNodeList
   NumberQuery::roseFunctionPointerOneParameter querySolverFunction){
   return AstQueryNamespace::queryRange(nodeList.begin(), nodeList.end(),
       std::ptr_fun(querySolverFunction));
+
 };
 NumberQuerySynthesizedAttributeType NumberQuery::queryNodeList 
 ( Rose_STL_Container<SgNode*> nodeList,
@@ -387,7 +388,7 @@ NumberQuerySynthesizedAttributeType NumberQuery::queryNodeList
   std::string targetNode,
   NumberQuery::roseFunctionPointerTwoParameters querySolverFunction ){
   return AstQueryNamespace::queryRange(nodeList.begin(), nodeList.end(),
-      std::bind2nd(std::ptr_fun(querySolverFunction), targetNode));
+      std::bind(std::ptr_fun(querySolverFunction), std::placeholders::_1, targetNode));
   //                                  std::bind2nd(getFunction(elementReturnType),traversal), defineQueryType);
 
 };
@@ -396,7 +397,7 @@ NumberQuerySynthesizedAttributeType NumberQuery::queryNodeList
   std::string targetNode,
   NumberQuery::TypeOfQueryTypeTwoParameters elementReturnType ){
   return AstQueryNamespace::queryRange(nodeList.begin(), nodeList.end(),
-      std::bind2nd(getFunction(elementReturnType), targetNode));
+      std::bind(getFunction(elementReturnType), std::placeholders::_1, targetNode));
 
 };
 
@@ -417,7 +418,7 @@ NumberQuery::queryMemoryPool
  NumberQuery::roseFunctionPointerTwoParameters querySolverFunction, VariantVector* targetVariantVector)
 {
   return AstQueryNamespace::queryMemoryPool(
-      std::bind2nd(std::ptr_fun(querySolverFunction),traversal), targetVariantVector);
+      std::bind(std::ptr_fun(querySolverFunction),std::placeholders::_1,traversal), targetVariantVector);
 
 };
 
@@ -460,7 +461,7 @@ NumberQuery::queryMemoryPool
  VariantVector* targetVariantVector)
 {
   return AstQueryNamespace::queryMemoryPool( 
-      std::bind2nd(getFunction(elementReturnType),traversal), targetVariantVector);
+      std::bind(getFunction(elementReturnType),std::placeholders::_1,traversal), targetVariantVector);
 
 
 };

--- a/src/midend/astQuery/numberQuery.h
+++ b/src/midend/astQuery/numberQuery.h
@@ -46,20 +46,21 @@ namespace NumberQuery{
 
   /**************************************************************************************************************
    * The function
-   *    std::pointer_to_unary_function<SgNode*, std::list<SgNode*> > getFunction(TypeOfQueryTypeOneParameter oneParam);
+   *    std::function<NumberQuerySynthesizedAttributeType(SgNode *)> getFunction(TypeOfQueryTypeOneParameter oneParam);
    * will return a functor wrapping the pre-implemented function for TypeOfQueryTypeOneParameter.
    **************************************************************************************************************/
 
-  std::pointer_to_unary_function < SgNode *,
-    NumberQuerySynthesizedAttributeType >getFunction (TypeOfQueryTypeOneParameter oneParam);
+  std::function<NumberQuerySynthesizedAttributeType(SgNode *)> getFunction(TypeOfQueryTypeOneParameter oneParam);
 
   /**************************************************************************************************************
    * The function
-   * std::pointer_to_binary_function<SgNode*, SgNode*, std::list<SgNode*> > getFunction(TypeOfQueryTypeTwoParameters twoParam);
+   *    std::function<NumberQuerySynthesizedAttributeType(SgNode *, std::string)>
+   *       getFunction(TypeOfQueryTypeTwoParameters twoParam);
    * will return a functor wrapping the pre-implemented function for TypeOfQueryTypeTwoParameters.
    **************************************************************************************************************/
-  std::pointer_to_binary_function < SgNode *, std::string,
-    NumberQuerySynthesizedAttributeType > getFunction (TypeOfQueryTypeTwoParameters twoParam);
+
+  std::function<NumberQuerySynthesizedAttributeType(SgNode *, std::string)>
+     getFunction(TypeOfQueryTypeTwoParameters twoParam);
 
   // get the SgNode's conforming to the test in querySolverFunction or
   // get the SgNode's conforming to the test in the TypeOfQueryTypeOneParamter the user specify.


### PR DESCRIPTION
I replaced the following functions that are deprecated in cpp11 and
removed in the cpp17 standard:

std::mem_fun_ref                       was replaced by std::mem_fn
std::bind2nd                               was replaced by std::bind
std::pointer_to_unary_function  was replaced by std::function
std::pointer_to_binary_function was replaced by std::function