### PR TITLE
Jovial develop - equivalence op and parentheses for unary ops

### DIFF
--- a/src/backend/unparser/JovialCodeGeneration/unparseJovial.h
+++ b/src/backend/unparser/JovialCodeGeneration/unparseJovial.h
@@ -91,6 +91,7 @@ class Unparse_Jovial : public UnparseLanguageIndependentConstructs
 
           virtual void unparseSubscriptExpr     (SgExpression* expr, SgUnparse_Info& info);
           virtual void unparseArrayOp           (SgExpression* expr, SgUnparse_Info& info);
+          virtual void unparseEqualityOp        (SgExpression* expr, SgUnparse_Info& info);
           virtual void unparseAsteriskShapeExpr (SgExpression* expr, SgUnparse_Info& info);
 
           virtual void unparseAssignOp       (SgExpression* expr, SgUnparse_Info& info);

--- a/src/backend/unparser/JovialCodeGeneration/unparseJovial_expressions.C
+++ b/src/backend/unparser/JovialCodeGeneration/unparseJovial_expressions.C
@@ -53,11 +53,11 @@ void Unparse_Jovial::unparseLanguageSpecificExpression(SgExpression* expr, SgUnp
           case V_SgLessOrEqualOp:       unparseBinaryOperator(expr,"<=", info);  break;
           case V_SgGreaterThanOp:       unparseBinaryOperator(expr, ">", info);  break;
           case V_SgGreaterOrEqualOp:    unparseBinaryOperator(expr,">=", info);  break;
-          case V_SgEqualityOp:          unparseBinaryOperator(expr, "=", info);  break;
           case V_SgNotEqualOp:          unparseBinaryOperator(expr,"<>", info);  break;
           case V_SgBitAndOp:            unparseBinaryOperator(expr,"AND", info); break;
           case V_SgBitOrOp:             unparseBinaryOperator(expr,"OR", info);  break;
           case V_SgBitXorOp:            unparseBinaryOperator(expr,"XOR", info); break;
+          case V_SgEqualityOp:          unparseEqualityOp    (expr,       info); break;
 
           case V_SgUnaryAddOp:          unparseUnaryOperator(expr, "+", info);   break;
           case V_SgMinusOp:             unparseUnaryOperator(expr, "-", info);   break;
@@ -243,6 +243,27 @@ Unparse_Jovial::unparseArrayOp(SgExpression* expr, SgUnparse_Info& info)
      curprint("(");
      unparseExpression(arrayRefExp->get_rhs_operand(),ninfo);
      curprint(")");
+   }
+
+void
+Unparse_Jovial::unparseEqualityOp(SgExpression* expr, SgUnparse_Info& info)
+   {
+     SgEqualityOp* eqOp = isSgEqualityOp(expr);
+     ROSE_ASSERT(eqOp);
+
+     SgExpression* lhs = eqOp->get_lhs_operand();
+     SgExpression* rhs = eqOp->get_rhs_operand();
+     SgType* lhs_type = lhs->get_type();
+     SgType* rhs_type = rhs->get_type();
+
+     if (isSgJovialBitType(lhs_type) && isSgJovialBitType(rhs_type))
+        {
+           unparseBinaryOperator(expr, "EQV", info);
+        }
+     else
+        {
+           unparseBinaryOperator(expr, "=", info);
+        }
    }
 
 void

--- a/src/backend/unparser/JovialCodeGeneration/unparseJovial_expressions.C
+++ b/src/backend/unparser/JovialCodeGeneration/unparseJovial_expressions.C
@@ -127,7 +127,14 @@ Unparse_Jovial::unparseUnaryOperator(SgExpression* expr, const char* op, SgUnpar
    {
      SgUnparse_Info ninfo(info);
      ninfo.set_operator_name(op);
+
+     bool need_parens = expr->get_need_paren();
+
+     if (need_parens) curprint("(");
+
      unparseUnaryExpr(expr, ninfo);
+
+     if (need_parens) curprint(")");
    }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Made changes in the unparser to correctly unparse equivalence op and parentheses for unary ops if needed.