### PR TITLE
Make set_name work for SgInitializedNames that reside inside of a SgF…

### DIFF
--- a/src/frontend/SageIII/sageInterface/sageInterface.C
+++ b/src/frontend/SageIII/sageInterface/sageInterface.C
@@ -1152,6 +1152,7 @@ SageInterface::set_name ( SgInitializedName *initializedNameNode, SgName new_nam
         {
           switch(parent_declaration->variantT())
              {
+               case V_SgFunctionParameterList:
                case V_SgVariableDeclaration:
                   {
                     if (isSgVariableSymbol((*it).second)!=NULL)


### PR DESCRIPTION
…unctionParameterList.

On an SgInitializedName residing inside a function parameter list `SgFunctionParameterList`, `parent_declaration->variantT()` will be `V_SgFunctionParameterList` which is not handelt by the current implementation.

This PR fixes this.