### PR TITLE
Fix: Check source tree for EDG binaries before downloading

### DIFF
--- a/src/frontend/CxxFrontend/Makefile.am
+++ b/src/frontend/CxxFrontend/Makefile.am
@@ -164,6 +164,10 @@ EDG.tar.gz: $(EDGBIN_SIGNATURE_FILE)
 
 	@if [ -r "$(EDGBIN_NAME).tar.gz" ]; then								\
 	    echo "EDG binary tarball appears to have been downloaded already: $(EDGBIN_NAME).tar.gz";		\
+	elif [ -r "$(top_srcdir)/src/frontend/CxxFrontend/$(EDGBIN_NAME).tar.gz" ]; then			\
+	    echo "EDG binary tarball found in source tree: $(EDGBIN_NAME).tar.gz";				\
+	    echo "Copying from source tree to build directory...";						\
+	    cp "$(top_srcdir)/src/frontend/CxxFrontend/$(EDGBIN_NAME).tar.gz" .;				\
 	else													\
 	    $(MAKE) check-network || exit 1;									\
 	    echo "Downloading EDG binary tarball: $(EDGBIN_NAME).tar.gz";					\


### PR DESCRIPTION
## Problem

When the EDG binary server (`edg-binaries.rosecompiler.org`) is unreachable, the build fails with:

```
ROSE web server http://edg-binaries.rosecompiler.org is not currently reachable
Please contact rose-public@nersc.gov to troubleshoot this error.
make[5]: *** [Makefile:1804: check-network] Error 1
make[4]: *** [Makefile:1827: EDG.tar.gz] Error 1
```

This happens even though EDG binaries are already present in the source tree at `src/frontend/CxxFrontend/roseBinaryEDG-*.tar.gz`.

## Root Cause

The current build logic in `Makefile.am`:
1. Checks if the tarball exists in the build directory
2. If not found, immediately tries to download from the server

It does not check if the binaries are available in the source tree.

## Solution

This patch adds a fallback step to check the source tree before attempting a network download:

1. First check if the tarball exists in the build directory (existing behavior)
2. **NEW**: Check if the tarball exists in the source tree (`$(top_srcdir)/src/frontend/CxxFrontend/`) and copy it if found
3. Only attempt network download if not found locally

## Benefits

- **Offline builds**: Users can build ROSE without network access if they have the complete source tree
- **Server resilience**: Builds succeed even when the EDG server is temporarily unavailable
- **No behavioral change**: If the binary is not in the source tree, the existing download logic is used

## Testing

Tested by building ROSE in a Docker container where the EDG server was unreachable. The build successfully found and used the EDG binary from the source tree.

## Changes

- `src/frontend/CxxFrontend/Makefile.am`: Added elif clause to check source tree before network download