### PR TITLE
Fix CMake to use local EDG binaries and add CI workflow

### DIFF
--- a/.github/workflows/cmake-build.yml
+++ b/.github/workflows/cmake-build.yml
@@ -1,0 +1,107 @@
+name: CMake Build CI
+
+on:
+  push:
+    branches: [ weekly ]
+  pull_request:
+    branches: [ weekly ]
+
+jobs:
+  cmake-build-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      # No submodules - EDG is proprietary. We use pre-built EDG binaries
+      # from src/frontend/CxxFrontend/roseBinaryEDG-*.tar.gz instead.
+    
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          build-essential gcc-11 g++-11 gfortran-11 \
+          flex bison \
+          libboost-all-dev libxml2-dev libreadline-dev \
+          zlib1g-dev libsqlite3-dev libpq-dev libyaml-dev \
+          libgmp-dev libmpc-dev libmpfr-dev \
+          wget curl
+        # Set GCC 11 as default (EDG binaries require GCC 7-12)
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 110
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 110
+        sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-11 110
+
+    - name: Install CMake (latest from Kitware)
+      run: |
+        CODENAME=$(lsb_release -cs)
+        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
+          gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+        echo "deb https://apt.kitware.com/ubuntu/ $CODENAME main" | \
+          sudo tee /etc/apt/sources.list.d/kitware.list
+        sudo apt-get update
+        sudo apt-get install -y cmake || {
+          echo "Kitware install failed, using system CMake"
+        }
+        cmake --version
+
+    - name: Check environment
+      run: |
+        echo "=== Build Environment ==="
+        gcc --version | head -1
+        g++ --version | head -1
+        cmake --version | head -1
+    
+    - name: Verify EDG binaries in source tree
+      run: |
+        echo "Checking for EDG binaries..."
+        ls -lh src/frontend/CxxFrontend/roseBinaryEDG-*.tar.gz
+        GCC_MAJOR=$(gcc -dumpversion | cut -d. -f1)
+        echo "GCC major version: $GCC_MAJOR"
+        ls src/frontend/CxxFrontend/roseBinaryEDG-*-gnu-${GCC_MAJOR}-*.tar.gz \
+          && echo "✅ Matching EDG binary found for GCC $GCC_MAJOR" \
+          || echo "⚠️ No matching EDG binary for GCC $GCC_MAJOR"
+    
+    - name: Configure with CMake
+      run: |
+        mkdir -p cmake-build rose-install
+        cd cmake-build
+        cmake .. \
+          -DCMAKE_INSTALL_PREFIX=$PWD/../rose-install \
+          -DENABLE_C=ON \
+          -DENABLE_TESTS=OFF \
+          -DCMAKE_BUILD_TYPE=Release
+    
+    - name: Build ROSE
+      run: |
+        cd cmake-build
+        make -j$(nproc)
+    
+    - name: Verify librose.so
+      run: |
+        LIBROSE=$(find cmake-build -name 'librose.so*' -type f | head -1)
+        if [ -n "$LIBROSE" ]; then
+          echo "✅ librose.so built successfully"
+          ls -lh cmake-build/lib/librose* 2>/dev/null
+          file "$LIBROSE"
+        else
+          echo "❌ librose.so not found"
+          exit 1
+        fi
+    
+    - name: Install ROSE
+      run: |
+        cd cmake-build
+        make install
+        ls -lh ../rose-install/lib/librose*
+    
+    - name: Build summary
+      if: always()
+      run: |
+        echo "=== Build Summary ==="
+        echo "CMake: $(cmake --version | head -1)"
+        echo "GCC: $(gcc --version | head -1)"
+        echo "Build dir: $(du -sh cmake-build 2>/dev/null | cut -f1)"
+        LIBROSE=$(find cmake-build -name 'librose.so*' -type f | head -1)
+        [ -n "$LIBROSE" ] && echo "✅ librose.so: $(ls -lh $LIBROSE | awk '{print $5}')" || echo "❌ librose.so: NOT FOUND"
+        INSTALLED=$(find rose-install -name 'librose.so*' -type f 2>/dev/null | head -1)
+        [ -n "$INSTALLED" ] && echo "✅ Installed: $(ls -lh $INSTALLED | awk '{print $5}')" || echo "❌ Installed: NOT FOUND"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -793,17 +793,42 @@ if(NOT have_EDG_source AND NOT ENABLE_CLANG_FRONTEND)
   if(ENABLE_C)
     set(BINARY_EDG 1)
     if(NOT WIN32)
-      message(FATAL_ERROR "EDG binary download not yet supported, please use EDG git submodule if in ROSE team, otherwise use autotools")
-      message(STATUS "EDG - downloading EDG-${EDG_VERSION} binary tar file")
-      if(EXISTS "${PROJECT_BINARY_DIR}/src/frontend/CxxFrontend/EDG.tar.gz")
-        execute_process(COMMAND "tar" "-zxvf" "-C" "${PROJECT_BINARY_DIR}/src/frontend/CxxFrontend/EDG")
+      # Check for EDG binaries in the source tree first (they're included in the weekly branch)
+      # EDG binaries are named like: roseBinaryEDG-6-5-x86_64-pc-linux-gnu-gnu-9-5.0.11.145.381.tar.gz
+      string(REPLACE "." "-" EDG_VERSION_DASH "${EDG_VERSION}")
+      
+      # Detect GCC major version
+      execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_FULL_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+      string(REGEX MATCH "^([0-9]+)" GCC_MAJOR_VERSION "${GCC_FULL_VERSION}")
+      
+      # Build the expected tarball pattern
+      set(EDG_TARBALL_PATTERN "roseBinaryEDG-${EDG_VERSION_DASH}-x86_64-pc-linux-gnu-gnu-${GCC_MAJOR_VERSION}-*.tar.gz")
+      set(EDG_SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/frontend/CxxFrontend")
+      
+      # Search for matching EDG tarball in source tree
+      file(GLOB EDG_TARBALLS "${EDG_SOURCE_DIR}/${EDG_TARBALL_PATTERN}")
+      
+      if(EDG_TARBALLS)
+        # Use the first matching tarball
+        list(GET EDG_TARBALLS 0 EDG_TARBALL_PATH)
+        get_filename_component(EDG_TARBALL_NAME "${EDG_TARBALL_PATH}" NAME)
+        message(STATUS "EDG - found binary tarball in source tree: ${EDG_TARBALL_NAME}")
+        
+        # Set up to copy and extract at build time
+        set(EDG_BUILD_DIR "${PROJECT_BINARY_DIR}/src/frontend/CxxFrontend")
+        set(EDG_USE_SOURCE_TREE_BINARY TRUE CACHE INTERNAL "Use EDG binary from source tree")
+        set(EDG_SOURCE_TARBALL "${EDG_TARBALL_PATH}" CACHE INTERNAL "Path to EDG binary tarball")
       else()
-      # no need to display this message after the file has been downloaded
-      if(NOT EXISTS "${PROJECT_BINARY_DIR}/src/frontend/CxxFrontend/EDG/.libs")
-        message(WARNING "At build time, CMake will attempt to download a required library tarball.\n"
-                        "Please note that EDG binary tarballs are available for only certain configurations.")
-      endif()
-      include(${PROJECT_SOURCE_DIR}/cmake/DownloadEDG.cmake)
+        message(STATUS "EDG - no matching binary found in source tree for GCC ${GCC_MAJOR_VERSION}")
+        message(STATUS "EDG - looking for pattern: ${EDG_TARBALL_PATTERN}")
+        message(STATUS "EDG - available tarballs:")
+        file(GLOB ALL_EDG_TARBALLS "${EDG_SOURCE_DIR}/roseBinaryEDG-*.tar.gz")
+        foreach(tarball ${ALL_EDG_TARBALLS})
+          get_filename_component(tarball_name "${tarball}" NAME)
+          message(STATUS "       ${tarball_name}")
+        endforeach()
+        message(FATAL_ERROR "No compatible EDG binary found for GCC ${GCC_MAJOR_VERSION}. "
+                           "Please use a supported GCC version (7-12) or use autotools build.")
       endif()
     endif()
   endif()
@@ -813,7 +838,12 @@ set(edg_lib EDG) # the compiled library, the downloaded library, or the dummy li
 if(have_EDG_source)
   message(STATUS "EDG - will compile EDG-${EDG_VERSION} source code")
 elseif(BINARY_EDG)
-  message(STATUS "EDG - will use EDG-${EDG_VERSION} binary release (download)")
+  if(EDG_USE_SOURCE_TREE_BINARY)
+    message(STATUS "EDG - will use EDG-${EDG_VERSION} binary from source tree")
+    # Include will be deferred until after rosetta_generated target is defined
+  else()
+    message(STATUS "EDG - will use EDG-${EDG_VERSION} binary release (download)")
+  endif()
 else()
   message(STATUS "EDG - not needed; using a nearly empty dummy library")
 endif()

--- a/cmake/UseLocalEDGBinary.cmake
+++ b/cmake/UseLocalEDGBinary.cmake
@@ -1,0 +1,39 @@
+# UseLocalEDGBinary.cmake
+# This module sets up build rules to use EDG binary tarballs from the source tree
+# instead of downloading them from the server.
+
+# Create the output directory
+set(EDG_BUILD_DIR "${CMAKE_BINARY_DIR}/src/frontend/CxxFrontend")
+file(MAKE_DIRECTORY "${EDG_BUILD_DIR}")
+
+# Get the tarball filename without path
+get_filename_component(EDG_TARBALL_NAME "${EDG_SOURCE_TARBALL}" NAME)
+
+# Get the directory name (tarball without .tar.gz)
+string(REGEX REPLACE "\\.tar\\.gz$" "" EDG_EXTRACTED_DIR "${EDG_TARBALL_NAME}")
+
+message(STATUS "EDG - will extract ${EDG_TARBALL_NAME} at build time")
+
+# Create a custom target to extract the EDG binary
+add_custom_target(extract_EDG_binary
+  COMMENT "Extracting EDG binary from source tree: ${EDG_TARBALL_NAME}"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${EDG_SOURCE_TARBALL}" "${EDG_BUILD_DIR}/${EDG_TARBALL_NAME}"
+  COMMAND ${CMAKE_COMMAND} -E tar xzf "${EDG_BUILD_DIR}/${EDG_TARBALL_NAME}"
+  COMMAND ${CMAKE_COMMAND} -E remove_directory "${EDG_BUILD_DIR}/EDG"
+  COMMAND ${CMAKE_COMMAND} -E rename "${EDG_BUILD_DIR}/${EDG_EXTRACTED_DIR}" "${EDG_BUILD_DIR}/EDG"
+  COMMAND ${CMAKE_COMMAND} -E touch "${EDG_BUILD_DIR}/EDG/libroseEDG.la"
+  WORKING_DIRECTORY "${EDG_BUILD_DIR}"
+  DEPENDS rosetta_generated
+)
+
+# Create the imported library target
+add_library(EDG STATIC IMPORTED)
+add_dependencies(EDG extract_EDG_binary)
+set_property(TARGET EDG PROPERTY IMPORTED_LOCATION
+  "${EDG_BUILD_DIR}/EDG/.libs/libroseEDG.a")
+
+# Also create EDG.tar.gz symlink for compatibility
+add_custom_command(TARGET extract_EDG_binary POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E create_symlink "${EDG_TARBALL_NAME}" "EDG.tar.gz"
+  WORKING_DIRECTORY "${EDG_BUILD_DIR}"
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -749,6 +749,27 @@ endforeach()
 set(rose_LIB_SRC_FILES dummyCppFileForLibrose.C)
 
 ########################################################################################################################
+# Link precompiled EDG binary library when not compiling EDG from source
+########################################################################################################################
+# When using a precompiled EDG binary (BINARY_EDG=1), we need to create an IMPORTED library
+# target and link it into librose.so. The EDG tarball is extracted by the extract_EDG_binary
+# custom target that runs after rosetta_generated.
+if(BINARY_EDG AND NOT have_EDG_source)
+  set(EDG_LIBRARY_PATH "${PROJECT_BINARY_DIR}/src/frontend/CxxFrontend/EDG/.libs/libroseEDG.a")
+  
+  # Create an IMPORTED static library for the precompiled EDG
+  add_library(roseEDG_precompiled STATIC IMPORTED GLOBAL)
+  set_target_properties(roseEDG_precompiled PROPERTIES
+    IMPORTED_LOCATION "${EDG_LIBRARY_PATH}"
+  )
+  
+  # The library will be available after extract_EDG_binary runs
+  # Mark that we have a precompiled EDG library to link
+  set(HAVE_PRECOMPILED_EDG TRUE)
+  message(STATUS "EDG - will link precompiled library: ${EDG_LIBRARY_PATH}")
+endif()
+
+########################################################################################################################
 # The ROSE library itself (librose.so, librose.a, librose.dll)
 ########################################################################################################################
 add_library(ROSE_DLL SHARED ${rose_LIB_SRCS})
@@ -924,6 +945,20 @@ target_link_libraries(ROSE_DLL
     # Note: Threads moved to PUBLIC above
     ${_rose_system_libraries}
 )
+
+# Link precompiled EDG library if using binary distribution
+if(HAVE_PRECOMPILED_EDG)
+  # Make sure ROSE_DLL depends on extract_EDG_binary to ensure library exists before linking
+  add_dependencies(ROSE_DLL extract_EDG_binary)
+  target_link_libraries(ROSE_DLL PRIVATE roseEDG_precompiled)
+  message(STATUS "EDG - added roseEDG_precompiled to ROSE_DLL link libraries")
+endif()
+
+# Link quadmath library if FLOAT128 support is enabled (required by EDG)
+if(SUPPORT_FLOAT128)
+  target_link_libraries(ROSE_DLL PRIVATE quadmath)
+  message(STATUS "Added quadmath library for FLOAT128 support")
+endif()
 
 # Explicitly add -pthread flag for both compilation and linking
 # This is necessary even when CMAKE_THREAD_LIBS_INIT is empty (threading in libc)

--- a/src/ROSETTA/src/CMakeLists.txt
+++ b/src/ROSETTA/src/CMakeLists.txt
@@ -177,3 +177,8 @@ add_custom_command(
 
 # a custom target depending on generated rosetta source and header files to trigger the building process
 add_custom_target(rosetta_generated ALL DEPENDS ${ROSETTA_HEADERS} ${ROSETTA_SRC} ${STORAGECLASSES_SRC})
+
+# Include EDG binary extraction if using source tree EDG binaries
+if(EDG_USE_SOURCE_TREE_BINARY)
+  include(${PROJECT_SOURCE_DIR}/cmake/UseLocalEDGBinary.cmake)
+endif()


### PR DESCRIPTION
CMake Build Fix:
- Detect EDG tarballs in src/frontend/CxxFrontend/ matching the current GCC version, eliminating the need for network access to download EDG
- New cmake/UseLocalEDGBinary.cmake module for tarball extraction
- Create IMPORTED library target for precompiled EDG (libroseEDG.a)
- Add quadmath library for FLOAT128 support

GitHub Actions CI:
- Build ROSE with CMake on ubuntu-latest (GCC 11)
- Install latest CMake from Kitware APT repository
- Verify EDG binary availability, configure, build, and install
- Verify librose.so creation (~40 min on GitHub-hosted runners)
- No submodule checkout — uses pre-built EDG binaries only
- Runs on push/PR to weekly branch

Tested: CI run #21964081386 passed (39m42s, librose.so built).